### PR TITLE
MEDIUM: Add support for "mode tcp"

### DIFF
--- a/consul/config.go
+++ b/consul/config.go
@@ -18,6 +18,7 @@ type Upstream struct {
 	Service          string
 	LocalBindAddress string
 	LocalBindPort    int
+	Protocol         string
 
 	TLS
 
@@ -47,6 +48,7 @@ func (n UpstreamNode) Equal(o UpstreamNode) bool {
 type Downstream struct {
 	LocalBindAddress string
 	LocalBindPort    int
+	Protocol         string
 	TargetAddress    string
 	TargetPort       int
 

--- a/consul/watcher.go
+++ b/consul/watcher.go
@@ -165,7 +165,9 @@ func (w *Watcher) startUpstream(up api.Upstream) {
 	}
 
 	if up.Config["protocol"] != nil {
-		u.Protocol = up.Config["protocol"].(string)
+		if p, ok := up.Config["protocol"].(string); ok {
+			u.Protocol = p
+		}
 	}
 
 	w.lock.Lock()

--- a/haproxy/state/downstream.go
+++ b/haproxy/state/downstream.go
@@ -10,10 +10,17 @@ import (
 func generateDownstream(opts Options, certStore CertificateStore, cfg consul.Downstream, state State) (State, error) {
 	feName := "front_downstream"
 	beName := "back_downstream"
+	feMode := models.FrontendModeHTTP
+	beMode := models.BackendModeHTTP
 
 	caPath, crtPath, err := certStore.CertsPath(cfg.TLS)
 	if err != nil {
 		return state, err
+	}
+
+	if cfg.Protocol != "" && cfg.Protocol == "tcp" {
+		feMode = models.FrontendModeTCP
+		beMode = models.BackendModeTCP
 	}
 
 	// Main config
@@ -22,7 +29,7 @@ func generateDownstream(opts Options, certStore CertificateStore, cfg consul.Dow
 			Name:           feName,
 			DefaultBackend: beName,
 			ClientTimeout:  &clientTimeout,
-			Mode:           models.FrontendModeHTTP,
+			Mode:           feMode,
 			Httplog:        opts.LogRequests,
 		},
 		Bind: models.Bind{
@@ -73,7 +80,7 @@ func generateDownstream(opts Options, certStore CertificateStore, cfg consul.Dow
 			Name:           beName,
 			ServerTimeout:  &serverTimeout,
 			ConnectTimeout: &connectTimeout,
-			Mode:           models.BackendModeHTTP,
+			Mode:           beMode,
 		},
 		Servers: []models.Server{
 			models.Server{

--- a/haproxy/state/upstream.go
+++ b/haproxy/state/upstream.go
@@ -10,14 +10,22 @@ import (
 func generateUpstream(opts Options, certStore CertificateStore, cfg consul.Upstream, oldState, newState State) (State, error) {
 	feName := fmt.Sprintf("front_%s", cfg.Service)
 	beName := fmt.Sprintf("back_%s", cfg.Service)
+	feMode := models.FrontendModeHTTP
+	beMode := models.BackendModeHTTP
 
 	fePort64 := int64(cfg.LocalBindPort)
+
+	if cfg.Protocol != "" && cfg.Protocol == "tcp" {
+		feMode = models.FrontendModeTCP
+		beMode = models.BackendModeTCP
+	}
+
 	fe := Frontend{
 		Frontend: models.Frontend{
 			Name:           feName,
 			DefaultBackend: beName,
 			ClientTimeout:  &clientTimeout,
-			Mode:           models.FrontendModeHTTP,
+			Mode:           feMode,
 			Httplog:        opts.LogRequests,
 		},
 		Bind: models.Bind{
@@ -45,7 +53,7 @@ func generateUpstream(opts Options, certStore CertificateStore, cfg consul.Upstr
 			Balance: &models.Balance{
 				Algorithm: models.BalanceAlgorithmLeastconn,
 			},
-			Mode: models.BackendModeHTTP,
+			Mode: beMode,
 		},
 	}
 	if opts.LogRequests && opts.LogSocket != "" {


### PR DESCRIPTION
New frontends and backends only had support for using models.FrontendModeHTTP
and models.BackendModeHTTP which limited them to "mode http" only. This commit
adds support for "mode tcp" using both upstream and downstream specific
configuration options. It defaults to http.

To use add a "config" option within an upstream similar to the below example:

Sample downstream service file for Redis

	{
	  "service": {
	    "name": "redis",
	    "port": 6379,
	    "connect": {
	      "sidecar_service": {
		"proxy" : {
		  "config": { "protocol" : "tcp" }
		}
	      }
	    }
	  }
	}

Sample upstream configuration:

      "upstreams": [{
	 "destination_name": "redis",
	 "local_bind_port": 6379,
	 "config": { "protocol" : "tcp" }
      }