### PR TITLE
Use interface to log in Consul package

### DIFF
--- a/consul/logger.go
+++ b/consul/logger.go
@@ -1,0 +1,13 @@
+package consul
+
+// Logger Allows replacing easily the logger.
+type Logger interface {
+	// Debugf Display debug message
+	Debugf(format string, args ...interface{})
+	// Infof Display info message
+	Infof(format string, args ...interface{})
+	// Warnf Display warning message
+	Warnf(format string, args ...interface{})
+	// Errorf Display error message
+	Errorf(format string, args ...interface{})
+}

--- a/consul/logger_testing.go
+++ b/consul/logger_testing.go
@@ -1,0 +1,32 @@
+package consul
+
+import "testing"
+
+type testingLogger struct {
+	t *testing.T
+}
+
+// Debugf Display debug message
+func (l *testingLogger) Debugf(format string, args ...interface{}) {
+	l.t.Logf(format, args...)
+}
+
+// Infof Display info message
+func (l *testingLogger) Infof(format string, args ...interface{}) {
+	l.t.Logf(format, args...)
+}
+
+// Warnf Display warning message
+func (l *testingLogger) Warnf(format string, args ...interface{}) {
+	l.t.Logf(format, args...)
+}
+
+// Errorf Display error message
+func (l *testingLogger) Errorf(format string, args ...interface{}) {
+	l.t.Logf(format, args...)
+}
+
+// NewTestingLogger creates a Logger for testing.T
+func NewTestingLogger(t *testing.T) Logger {
+	return &testingLogger{t: t}
+}

--- a/haproxy/haproxy_cmd/run.go
+++ b/haproxy/haproxy_cmd/run.go
@@ -69,6 +69,7 @@ func Start(sd *lib.Shutdown, cfg Config) (*dataplane.Dataplane, error) {
 
 		err = dataplaneClient.Ping()
 		if err != nil {
+			fmt.Println("*****\n* SOUCHAY: wait for dataplane to be up\n*****")
 			time.Sleep(100 * time.Millisecond)
 			continue
 		}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,28 @@ import (
 	"github.com/criteo/haproxy-consul-connect/consul"
 )
 
+type consulLogger struct{}
+
+// Debugf Display debug message
+func (consulLogger) Debugf(format string, args ...interface{}) {
+	log.Debugf(format, args...)
+}
+
+// Infof Display info message
+func (consulLogger) Infof(format string, args ...interface{}) {
+	log.Infof(format, args...)
+}
+
+// Warnf Display warning message
+func (consulLogger) Warnf(format string, args ...interface{}) {
+	log.Infof(format, args...)
+}
+
+// Errorf Display error message
+func (consulLogger) Errorf(format string, args ...interface{}) {
+	log.Errorf(format, args...)
+}
+
 func main() {
 	logLevel := flag.String("log-level", "INFO", "Log level")
 	consulAddr := flag.String("http-addr", "127.0.0.1:8500", "Consul agent address")
@@ -73,7 +95,8 @@ func main() {
 		log.Fatalf("Please specify -sidecar-for or -sidecar-for-tag")
 	}
 
-	watcher := consul.New(serviceID, consulClient)
+	consulLogger := &consulLogger{}
+	watcher := consul.New(serviceID, consulClient, consulLogger)
 	go func() {
 		if err := watcher.Run(); err != nil {
 			log.Error(err)

--- a/utils_test.go
+++ b/utils_test.go
@@ -64,7 +64,7 @@ func startConnectService(t *testing.T, sd *lib.Shutdown, client *api.Client, reg
 
 	errs := make(chan error, 2)
 
-	watcher := consul.New(reg.ID, client)
+	watcher := consul.New(reg.ID, client, consul.NewTestingLogger(t))
 	go func() {
 		err := watcher.Run()
 		if err != nil {


### PR DESCRIPTION
This will allow to replace log implementation by testing one
to include tests into the Consul repository without adding
a new dependency