### PR TITLE
[BUGFIX] Properly detect failure to launch process

### DIFF
--- a/haproxy/haproxy_cmd/cmd.go
+++ b/haproxy/haproxy_cmd/cmd.go
@@ -24,6 +24,10 @@ func runCommand(sd *lib.Shutdown, cmdPath string, args ...string) (*exec.Cmd, er
 		sd.Done()
 		return nil, errors.Wrapf(err, "error starting %s", file)
 	}
+	if cmd.Process == nil {
+		sd.Done()
+		return nil, errors.Wrapf(err, "Process '%s' could not be started", file)
+	}
 	exited := uint32(0)
 	go func() {
 		defer sd.Done()

--- a/haproxy/haproxy_cmd/cmd_test.go
+++ b/haproxy/haproxy_cmd/cmd_test.go
@@ -1,0 +1,25 @@
+package haproxy_cmd
+
+import (
+	"testing"
+
+	"github.com/criteo/haproxy-consul-connect/lib"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_runCommand_ok(t *testing.T) {
+	t.Parallel()
+	sd := lib.NewShutdown()
+	cmd, err := runCommand(sd, "ls", ".")
+	assert.NoError(t, err)
+	cmd.Wait()
+}
+
+func Test_runCommand_nok_wrong_path(t *testing.T) {
+	t.Parallel()
+	sd := lib.NewShutdown()
+	cmd, err := runCommand(sd, "/path/to/nowhere/that/can/be/found/myExec", "--help")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "no such file or directory")
+	assert.Nil(t, cmd)
+}


### PR DESCRIPTION
In order to properly detect dataplaneapi/haproxy not launching, `cmd.Process != nil` needs to be checked as documented in Go APIs.