### PR TITLE
When test went wrong, test was not stopping properly.

### DIFF
--- a/haproxy/config.go
+++ b/haproxy/config.go
@@ -113,16 +113,19 @@ func newHaConfig(baseDir string, sd *lib.Shutdown) (*haConfig, error) {
 		DataplanePass: dataplanePass,
 	})
 	if err != nil {
+		sd.Done()
 		return nil, err
 	}
 
 	spoeCfgFile, err := os.OpenFile(cfg.SPOE, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
 	if err != nil {
+		sd.Done()
 		return nil, err
 	}
 	defer spoeCfgFile.Close()
 	_, err = spoeCfgFile.WriteString(spoeConfTmpl)
 	if err != nil {
+		sd.Done()
 		return nil, err
 	}
 

--- a/haproxy_test.go
+++ b/haproxy_test.go
@@ -14,12 +14,11 @@ import (
 
 func TestSetup(t *testing.T) {
 	sd := lib.NewShutdown()
+	client := startAgent(t, sd)
 	defer func() {
 		sd.Shutdown("test end")
 		sd.Wait()
 	}()
-
-	client := startAgent(t, sd)
 
 	csd, _, upstreamPorts := startConnectService(t, sd, client, &api.AgentServiceRegistration{
 		Name: "source",
@@ -50,9 +49,7 @@ func TestSetup(t *testing.T) {
 	})
 
 	startServer(t, sd, servicePort, "hello connect")
-
-	wait(csd, tsd)
-
+	wait(sd, csd, tsd)
 	res, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d", upstreamPorts["target"]))
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)

--- a/utils_test.go
+++ b/utils_test.go
@@ -27,7 +27,6 @@ func startAgent(t *testing.T, sd *lib.Shutdown) *api.Client {
 	go func() {
 		defer sd.Done()
 		<-sd.Stop
-
 		a.Shutdown()
 	}()
 
@@ -179,8 +178,14 @@ func testGetReq(t *testing.T, port int, expectedCode int, exptectedContent strin
 	}
 }
 
-func wait(c ...chan struct{}) {
+func wait(sd *lib.Shutdown, c ...chan struct{}) {
 	for _, o := range c {
-		<-o
+		select {
+		case <-sd.Stop:
+			return
+		case <-o:
+			continue
+
+		}
 	}
 }


### PR DESCRIPTION
In the case where the Process dataplaneapi was not activated for instance, the process was hanging forever.

Combined with https://github.com/haproxytech/haproxy-consul-connect/pull/21 it will stop the test immediately if dataplaneapi or haproxy are not in the path