### PR TITLE
FEATURE Check dataplaneapi and haproxy binaries

### DIFF
--- a/haproxy/haproxy.go
+++ b/haproxy/haproxy.go
@@ -36,10 +36,10 @@ type HAProxy struct {
 
 func New(consulClient *api.Client, cfg chan consul.Config, opts Options) *HAProxy {
 	if opts.HAProxyBin == "" {
-		opts.HAProxyBin = "haproxy"
+		opts.HAProxyBin = haproxy_cmd.DefaultHAProxyBin
 	}
 	if opts.DataplaneBin == "" {
-		opts.DataplaneBin = "dataplaneapi"
+		opts.DataplaneBin = haproxy_cmd.DefaultDataplaneBin
 	}
 	return &HAProxy{
 		opts:         opts,

--- a/haproxy/state/from_ha_test.go
+++ b/haproxy/state/from_ha_test.go
@@ -129,6 +129,10 @@ RHmDi0qnL6qrKfjTOnfHgQPCgxAy9knMIiDzBRg=
 }
 
 func TestFromHA(t *testing.T) {
+	err := haproxy_cmd.CheckEnvironment(haproxy_cmd.DefaultDataplaneBin, haproxy_cmd.DefaultHAProxyBin)
+	if err != nil {
+		t.Skipf("CANNOT Run test because of missing requirement: %s", err.Error())
+	}
 	cfgDir, err := ioutil.TempDir("/tmp", t.Name())
 	require.NoError(t, err)
 


### PR DESCRIPTION
when HAProxy is run with -version, it will also check for its external dependencies

Also skip the test with a message if those binaries are not present