### PR TITLE
Add enable_forwardfor option

### DIFF
--- a/consul/config.go
+++ b/consul/config.go
@@ -51,6 +51,7 @@ type Downstream struct {
 	Protocol         string
 	TargetAddress    string
 	TargetPort       int
+	EnableForwardFor bool
 
 	TLS
 }

--- a/haproxy/state/downstream.go
+++ b/haproxy/state/downstream.go
@@ -74,6 +74,13 @@ func generateDownstream(opts Options, certStore CertificateStore, cfg consul.Dow
 
 	state.Frontends = append(state.Frontends, fe)
 
+	var forwardFor *models.Forwardfor
+	if cfg.EnableForwardFor && beMode == models.BackendModeHTTP {
+		forwardFor = &models.Forwardfor{
+			Enabled: stringp(models.ForwardforEnabledEnabled),
+		}
+	}
+
 	// Backend
 	be := Backend{
 		Backend: models.Backend{
@@ -81,6 +88,7 @@ func generateDownstream(opts Options, certStore CertificateStore, cfg consul.Dow
 			ServerTimeout:  &serverTimeout,
 			ConnectTimeout: &connectTimeout,
 			Mode:           beMode,
+			Forwardfor:     forwardFor,
 		},
 		Servers: []models.Server{
 			models.Server{

--- a/haproxy/state/utils.go
+++ b/haproxy/state/utils.go
@@ -23,3 +23,7 @@ func int64p(i int) *int64 {
 	s := int64(i)
 	return &s
 }
+
+func stringp(s string) *string {
+	return &s
+}


### PR DESCRIPTION
This adds an option to enable X-Forwarded-For in the downstream backend.
This allows for the destination app to know where the request originated
from.

Example config :
```
{
  "service": {
    "name": "socat",
    "port": 8181,
    "connect": {
      "sidecar_service": {
        "proxy": {
          "config": {
            "enable_forwardfor": true
          }
        }
      }
    }
  }
}
```

In Addition this fixes how the proxy options are read.