### PR TITLE
MAJOR: go-version: update Go min. version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/haproxytech/haproxy-consul-connect
 
-go 1.12
+go 1.13
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a // indirect


### PR DESCRIPTION
with https://github.com/haproxytech/haproxy-consul-connect/commit/6a6fdaa29e3779376c5b7c75934c0142c1971458 commit
Milliseconds() is used. Since it is a Go 1.13 feature, Go min. version is updated from 1.12 to 1.13 in go.mod file