### PR TITLE
Add support for prepared queries

### DIFF
--- a/consul/config.go
+++ b/consul/config.go
@@ -15,7 +15,7 @@ type Config struct {
 }
 
 type Upstream struct {
-	Service          string
+	Name             string
 	LocalBindAddress string
 	LocalBindPort    int
 	Protocol         string

--- a/haproxy/state/snapshot_test.go
+++ b/haproxy/state/snapshot_test.go
@@ -21,7 +21,7 @@ func GetTestConsulConfig() consul.Config {
 		},
 		Upstreams: []consul.Upstream{
 			consul.Upstream{
-				Service:          "service_1",
+				Name:             "service_1",
 				LocalBindAddress: "127.0.0.1",
 				LocalBindPort:    10000,
 				Nodes: []consul.UpstreamNode{

--- a/haproxy/state/upstream.go
+++ b/haproxy/state/upstream.go
@@ -8,8 +8,8 @@ import (
 )
 
 func generateUpstream(opts Options, certStore CertificateStore, cfg consul.Upstream, oldState, newState State) (State, error) {
-	feName := fmt.Sprintf("front_%s", cfg.Service)
-	beName := fmt.Sprintf("back_%s", cfg.Service)
+	feName := fmt.Sprintf("front_%s", cfg.Name)
+	beName := fmt.Sprintf("back_%s", cfg.Name)
 	feMode := models.FrontendModeHTTP
 	beMode := models.BackendModeHTTP
 

--- a/haproxy_test.go
+++ b/haproxy_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"testing"
+	"time"
 
 	"net/http"
 
@@ -13,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSetup(t *testing.T) {
+func TestService(t *testing.T) {
 	err := haproxy_cmd.CheckEnvironment(haproxy_cmd.DefaultDataplaneBin, haproxy_cmd.DefaultHAProxyBin)
 	if err != nil {
 		t.Skipf("CANNOT Run test because of missing requirement: %s", err.Error())
@@ -63,4 +64,73 @@ func TestSetup(t *testing.T) {
 	require.NoError(t, err)
 	res.Body.Close()
 	require.Equal(t, "hello connect", string(body))
+}
+
+func TestPreparedQuery(t *testing.T) {
+	err := haproxy_cmd.CheckEnvironment(haproxy_cmd.DefaultDataplaneBin, haproxy_cmd.DefaultHAProxyBin)
+	if err != nil {
+		t.Skipf("CANNOT Run test because of missing requirement: %s", err.Error())
+	}
+	sd := lib.NewShutdown()
+	client := startAgent(t, sd)
+	defer func() {
+		sd.Shutdown("test end")
+		sd.Wait()
+	}()
+
+	_, _, err = client.PreparedQuery().Create(&api.PreparedQueryDefinition{
+		Name: "pq-",
+		Service: api.ServiceQuery{
+			Service:     "${match(1)}",
+			OnlyPassing: true,
+		},
+		Template: api.QueryTemplate{
+			Type:   "name_prefix_match",
+			Regexp: "^pq-(.+)$",
+		},
+	}, &api.WriteOptions{})
+	require.NoError(t, err)
+
+	csd, _, upstreamPorts := startConnectService(t, sd, client, &api.AgentServiceRegistration{
+		Name: "source",
+		ID:   "source-1",
+
+		Connect: &api.AgentServiceConnect{
+			SidecarService: &api.AgentServiceRegistration{
+				Proxy: &api.AgentServiceConnectProxyConfig{
+					Upstreams: []api.Upstream{
+						api.Upstream{
+							DestinationType: api.UpstreamDestTypePreparedQuery,
+							DestinationName: "pq-target",
+							Config: map[string]interface{}{
+								"poll_interval": (100 * time.Millisecond).String(),
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	tsd, servicePort, _ := startConnectService(t, sd, client, &api.AgentServiceRegistration{
+		Name: "target",
+		ID:   "target-1",
+
+		Connect: &api.AgentServiceConnect{
+			SidecarService: &api.AgentServiceRegistration{
+				Proxy: &api.AgentServiceConnectProxyConfig{},
+			},
+		},
+	})
+
+	startServer(t, sd, servicePort, "hello connect prepared query")
+	wait(sd, csd, tsd)
+	res, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d", upstreamPorts["pq-target"]))
+	require.NoError(t, err)
+	require.Equal(t, 200, res.StatusCode)
+
+	body, err := ioutil.ReadAll(res.Body)
+	require.NoError(t, err)
+	res.Body.Close()
+	require.Equal(t, "hello connect prepared query", string(body))
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -139,7 +139,7 @@ func startServer(t *testing.T, sd *lib.Shutdown, port int, response string) {
 	sd.Add(1)
 	go func() {
 		http.Serve(lis, http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-			rw.Write([]byte("hello connect"))
+			rw.Write([]byte(response))
 		}))
 	}()
 	go func() {


### PR DESCRIPTION
This adds support for prepared queries destinations in addition to
service ones: an upstream can now target a prepared query and benefit
from features such as fallback between DCs.
Since prepared queries do not support bloquing requests this uses polling
to periodically check for changes. The default polling rate is 30s: the
same as the one consul uses, and can be overriden with the "poll_interval"
config option.