### PR TITLE
CLEANUP: environment-check: remove redundant slice

### DIFF
--- a/haproxy/haproxy_cmd/run.go
+++ b/haproxy/haproxy_cmd/run.go
@@ -113,7 +113,7 @@ func execAndCapture(path string, re *regexp.Regexp) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("Failed executing %s: %s", path, err.Error())
 	}
-	return string(re.Find([]byte(out))), nil
+	return string(re.Find(out)), nil
 }
 
 // CheckEnvironment Verifies that all dependencies are correct


### PR DESCRIPTION
`Find` func accepts slice array and since `out` variable satisfies this,
there is no need for additional `[]byte(out)` call.