### PR TITLE
Fix: recreate backends when certificates change

### DIFF
--- a/haproxy/state/apply.go
+++ b/haproxy/state/apply.go
@@ -170,9 +170,22 @@ func applyBackends(ha HAProxy, old, new []Backend) error {
 }
 
 func shouldRecreateBackend(old, new Backend) bool {
-	return !reflect.DeepEqual(old.Backend, new.Backend) ||
+	if !reflect.DeepEqual(old.Backend, new.Backend) ||
 		!reflect.DeepEqual(old.LogTarget, new.LogTarget) ||
-		len(old.Servers) != len(new.Servers)
+		len(old.Servers) != len(new.Servers) {
+		return true
+	}
+
+	for i := range old.Servers {
+		if old.Servers[i].SslCafile != new.Servers[i].SslCafile {
+			return true
+		}
+		if old.Servers[i].SslCertificate != new.Servers[i].SslCertificate {
+			return true
+		}
+	}
+
+	return false
 }
 
 func shouldUpdateServer(old, new models.Server) bool {

--- a/haproxy/state/apply_backend_test.go
+++ b/haproxy/state/apply_backend_test.go
@@ -276,6 +276,58 @@ func TestRemoveServerSameSize(t *testing.T) {
 	)
 }
 
+func TestDifferentCerts(t *testing.T) {
+	old := State{
+		Backends: []Backend{
+			Backend{
+				Backend: models.Backend{
+					Name: "back",
+				},
+				Servers: []models.Server{
+					models.Server{
+						Name:           "srv_0",
+						Address:        "1.2.3.4",
+						Port:           int64p(8080),
+						Maintenance:    models.ServerMaintenanceDisabled,
+						SslCafile:      "test",
+						SslCertificate: "test1",
+					},
+				},
+			},
+		},
+	}
+	new := State{
+		Backends: []Backend{
+			Backend{
+				Backend: models.Backend{
+					Name: "back",
+				},
+				Servers: []models.Server{
+					models.Server{
+						Name:           "srv_0",
+						Address:        "1.2.3.4",
+						Port:           int64p(8080),
+						Maintenance:    models.ServerMaintenanceDisabled,
+						SslCafile:      "test",
+						SslCertificate: "test2",
+					},
+				},
+			},
+		},
+	}
+
+	ha := &fakeHA{}
+
+	err := Apply(ha, old, new)
+	require.Nil(t, err)
+
+	ha.RequireOps(t,
+		RequireOp(haOpDeleteBackend, "back"),
+		RequireOp(haOpCreateBackend, "back"),
+		RequireOp(haOpCreateServer, "srv_0"),
+	)
+}
+
 func TestBackendChange(t *testing.T) {
 	old := State{
 		Backends: []Backend{


### PR DESCRIPTION
When certificates changed servers where only updated, which didn't
change the certificates. This fixes it by recreating the backend on
certificate update.