### PR TITLE
Keep original server names in HAproxy backends

### DIFF
--- a/consul/config.go
+++ b/consul/config.go
@@ -32,13 +32,14 @@ func (n Upstream) Equal(o Upstream) bool {
 }
 
 type UpstreamNode struct {
-	Host   string
-	Port   int
-	Weight int
+	Name    string
+	Address string
+	Port    int
+	Weight  int
 }
 
 func (n UpstreamNode) ID() string {
-	return fmt.Sprintf("%s:%d", n.Host, n.Port)
+	return fmt.Sprintf("%s:%d", n.Address, n.Port)
 }
 
 func (n UpstreamNode) Equal(o UpstreamNode) bool {

--- a/consul/watcher.go
+++ b/consul/watcher.go
@@ -454,9 +454,12 @@ func (w *Watcher) genCfg() Config {
 		}
 		for _, s := range up.Nodes {
 			serviceInstancesTotal++
-			host := s.Service.Address
-			if host == "" {
-				host = s.Node.Address
+
+			name := s.Node.Node
+
+			address := s.Service.Address
+			if address == "" {
+				address = s.Node.Address
 			}
 
 			weight := 1
@@ -474,9 +477,10 @@ func (w *Watcher) genCfg() Config {
 			serviceInstancesAlive++
 
 			upstream.Nodes = append(upstream.Nodes, UpstreamNode{
-				Host:   host,
-				Port:   s.Service.Port,
-				Weight: weight,
+				Name:    name,
+				Address: address,
+				Port:    s.Service.Port,
+				Weight:  weight,
 			})
 		}
 

--- a/haproxy/dataplane/backend.go
+++ b/haproxy/dataplane/backend.go
@@ -58,15 +58,15 @@ func (t *tnx) CreateServer(beName string, srv models.Server) error {
 	return t.client.makeReq(http.MethodPost, fmt.Sprintf("/v1/services/haproxy/configuration/servers?backend=%s&transaction_id=%s", beName, t.txID), srv, nil)
 }
 
-func (t *tnx) ReplaceServer(beName string, srv models.Server) error {
+func (t *tnx) ReplaceServer(beName string, oldSrvName string, newSrv models.Server) error {
 	t.After(func() error {
-		return t.client.ReplaceServer(beName, srv)
+		return t.client.ReplaceServer(beName, oldSrvName, newSrv)
 	})
 	return nil
 }
 
-func (c *Dataplane) ReplaceServer(beName string, srv models.Server) error {
-	err := c.makeReq(http.MethodPut, fmt.Sprintf("/v1/services/haproxy/configuration/servers/%s?backend=%s&version=%d", srv.Name, beName, c.version), srv, nil)
+func (c *Dataplane) ReplaceServer(beName string, oldSrvName string, newSrv models.Server) error {
+	err := c.makeReq(http.MethodPut, fmt.Sprintf("/v1/services/haproxy/configuration/servers/%s?backend=%s&version=%d", oldSrvName, beName, c.version), newSrv, nil)
 	if err != nil {
 		return err
 	}

--- a/haproxy/state/apply.go
+++ b/haproxy/state/apply.go
@@ -151,7 +151,7 @@ func applyBackends(ha HAProxy, old, new []Backend) error {
 					continue
 				}
 
-				err := ha.ReplaceServer(newBack.Backend.Name, s)
+				err := ha.ReplaceServer(newBack.Backend.Name, oldServers[i].Name, s)
 				if err != nil {
 					return err
 				}

--- a/haproxy/state/apply_backend_test.go
+++ b/haproxy/state/apply_backend_test.go
@@ -65,7 +65,7 @@ func TestNoChangeBackend(t *testing.T) {
 				},
 				Servers: []models.Server{
 					models.Server{
-						Name:        "srv_0",
+						Name:        "some-server",
 						Address:     "1.2.3.4",
 						Port:        int64p(8080),
 						Maintenance: models.ServerMaintenanceDisabled,
@@ -82,7 +82,7 @@ func TestNoChangeBackend(t *testing.T) {
 				},
 				Servers: []models.Server{
 					models.Server{
-						Name:        "srv_0",
+						Name:        "some-server",
 						Address:     "1.2.3.4",
 						Port:        int64p(8080),
 						Maintenance: models.ServerMaintenanceDisabled,
@@ -138,7 +138,7 @@ func TestAddServerDifferentSize(t *testing.T) {
 				},
 				Servers: []models.Server{
 					models.Server{
-						Name:        "srv_0",
+						Name:        "some-server",
 						Address:     "1.2.3.4",
 						Port:        int64p(8080),
 						Maintenance: models.ServerMaintenanceDisabled,
@@ -156,7 +156,7 @@ func TestAddServerDifferentSize(t *testing.T) {
 	ha.RequireOps(t,
 		RequireOp(haOpDeleteBackend, "back"),
 		RequireOp(haOpCreateBackend, "back"),
-		RequireOp(haOpCreateServer, "srv_0"),
+		RequireOp(haOpCreateServer, "some-server"),
 	)
 }
 
@@ -169,13 +169,13 @@ func TestAddServerSameSize(t *testing.T) {
 				},
 				Servers: []models.Server{
 					models.Server{
-						Name:        "srv_0",
+						Name:        "some-server",
 						Address:     "1.2.3.4",
 						Port:        int64p(8080),
 						Maintenance: models.ServerMaintenanceDisabled,
 					},
 					models.Server{
-						Name:        "srv_1",
+						Name:        "disabled_server_0",
 						Address:     "127.0.0.1",
 						Port:        int64p(1),
 						Maintenance: models.ServerMaintenanceEnabled,
@@ -192,13 +192,13 @@ func TestAddServerSameSize(t *testing.T) {
 				},
 				Servers: []models.Server{
 					models.Server{
-						Name:        "srv_0",
+						Name:        "some-server",
 						Address:     "1.2.3.4",
 						Port:        int64p(8080),
 						Maintenance: models.ServerMaintenanceDisabled,
 					},
 					models.Server{
-						Name:        "srv_1",
+						Name:        "different-server",
 						Address:     "1.2.3.5",
 						Port:        int64p(8081),
 						Maintenance: models.ServerMaintenanceDisabled,
@@ -214,7 +214,7 @@ func TestAddServerSameSize(t *testing.T) {
 	require.Nil(t, err)
 
 	ha.RequireOps(t,
-		RequireOp(haOpReplaceServer, "srv_1"),
+		RequireOp(haOpReplaceServer, "disabled_server_0"),
 	)
 }
 
@@ -227,13 +227,13 @@ func TestRemoveServerSameSize(t *testing.T) {
 				},
 				Servers: []models.Server{
 					models.Server{
-						Name:        "srv_0",
+						Name:        "some-server",
 						Address:     "1.2.3.4",
 						Port:        int64p(8080),
 						Maintenance: models.ServerMaintenanceDisabled,
 					},
 					models.Server{
-						Name:        "srv_1",
+						Name:        "different-server",
 						Address:     "1.2.3.5",
 						Port:        int64p(8081),
 						Maintenance: models.ServerMaintenanceDisabled,
@@ -250,13 +250,13 @@ func TestRemoveServerSameSize(t *testing.T) {
 				},
 				Servers: []models.Server{
 					models.Server{
-						Name:        "srv_0",
+						Name:        "disabled_server_0",
 						Address:     "127.0.0.1",
 						Port:        int64p(1),
 						Maintenance: models.ServerMaintenanceEnabled,
 					},
 					models.Server{
-						Name:        "srv_1",
+						Name:        "different-server",
 						Address:     "1.2.3.5",
 						Port:        int64p(8081),
 						Maintenance: models.ServerMaintenanceDisabled,
@@ -272,7 +272,7 @@ func TestRemoveServerSameSize(t *testing.T) {
 	require.Nil(t, err)
 
 	ha.RequireOps(t,
-		RequireOp(haOpReplaceServer, "srv_0"),
+		RequireOp(haOpReplaceServer, "some-server"),
 	)
 }
 
@@ -285,7 +285,7 @@ func TestDifferentCerts(t *testing.T) {
 				},
 				Servers: []models.Server{
 					models.Server{
-						Name:           "srv_0",
+						Name:           "some-server",
 						Address:        "1.2.3.4",
 						Port:           int64p(8080),
 						Maintenance:    models.ServerMaintenanceDisabled,
@@ -304,7 +304,7 @@ func TestDifferentCerts(t *testing.T) {
 				},
 				Servers: []models.Server{
 					models.Server{
-						Name:           "srv_0",
+						Name:           "some-server",
 						Address:        "1.2.3.4",
 						Port:           int64p(8080),
 						Maintenance:    models.ServerMaintenanceDisabled,
@@ -324,7 +324,7 @@ func TestDifferentCerts(t *testing.T) {
 	ha.RequireOps(t,
 		RequireOp(haOpDeleteBackend, "back"),
 		RequireOp(haOpCreateBackend, "back"),
-		RequireOp(haOpCreateServer, "srv_0"),
+		RequireOp(haOpCreateServer, "some-server"),
 	)
 }
 
@@ -337,7 +337,7 @@ func TestBackendChange(t *testing.T) {
 				},
 				Servers: []models.Server{
 					models.Server{
-						Name:        "srv_0",
+						Name:        "some-server",
 						Address:     "1.2.3.4",
 						Port:        int64p(8080),
 						Maintenance: models.ServerMaintenanceDisabled,
@@ -355,7 +355,7 @@ func TestBackendChange(t *testing.T) {
 				},
 				Servers: []models.Server{
 					models.Server{
-						Name:        "srv_0",
+						Name:        "some-server",
 						Address:     "1.2.3.4",
 						Port:        int64p(8080),
 						Maintenance: models.ServerMaintenanceDisabled,
@@ -373,6 +373,6 @@ func TestBackendChange(t *testing.T) {
 	ha.RequireOps(t,
 		RequireOp(haOpDeleteBackend, "back"),
 		RequireOp(haOpCreateBackend, "back"),
-		RequireOp(haOpCreateServer, "srv_0"),
+		RequireOp(haOpCreateServer, "some-server"),
 	)
 }

--- a/haproxy/state/fake_ha_test.go
+++ b/haproxy/state/fake_ha_test.go
@@ -98,10 +98,10 @@ func (h *fakeHA) CreateServer(beName string, srv models.Server) error {
 	return nil
 }
 
-func (h *fakeHA) ReplaceServer(beName string, srv models.Server) error {
+func (h *fakeHA) ReplaceServer(beName string, oldSrvName string, newSrv models.Server) error {
 	h.ops = append(h.ops, fakeHAOp{
 		Type: haOpReplaceServer,
-		Name: srv.Name,
+		Name: oldSrvName,
 	})
 	return nil
 }

--- a/haproxy/state/states.go
+++ b/haproxy/state/states.go
@@ -28,7 +28,7 @@ type HAProxy interface {
 	DeleteBackend(name string) error
 	CreateBackend(be models.Backend) error
 	CreateServer(beName string, srv models.Server) error
-	ReplaceServer(beName string, srv models.Server) error
+	ReplaceServer(beName string, oldSrvName string, newSrv models.Server) error
 	DeleteServer(beName string, name string) error
 	CreateFilter(parentType, parentName string, filter models.Filter) error
 	CreateTCPRequestRule(parentType, parentName string, rule models.TCPRequestRule) error

--- a/haproxy/state/upstream.go
+++ b/haproxy/state/upstream.go
@@ -85,7 +85,7 @@ func generateUpstreamServers(opts Options, certStore CertificateStore, cfg consu
 		return fmt.Sprintf("%s:%d", s.Address, *s.Port)
 	}
 	idxConsulNode := func(s consul.UpstreamNode) string {
-		return fmt.Sprintf("%s:%d", s.Host, s.Port)
+		return fmt.Sprintf("%s:%d", s.Address, s.Port)
 	}
 
 	servers := make([]models.Server, len(oldBackend.Servers))
@@ -124,7 +124,7 @@ func generateUpstreamServers(opts Options, certStore CertificateStore, cfg consu
 		}
 
 		servers[i] = disabledServer
-		servers[i].Name = fmt.Sprintf("srv_%d", i)
+		servers[i].Name = fmt.Sprintf("disabled_server_%d", i)
 		emptyServerSlots = append(emptyServerSlots, i)
 	}
 
@@ -143,7 +143,7 @@ func generateUpstreamServers(opts Options, certStore CertificateStore, cfg consu
 			}
 			for i := 0; i < add; i++ {
 				server := disabledServer
-				server.Name = fmt.Sprintf("srv_%d", i+l)
+				server.Name = fmt.Sprintf("disabled_server_%d", i+l)
 				servers = append(servers, server)
 				emptyServerSlots = append(emptyServerSlots, i+l)
 			}
@@ -152,7 +152,8 @@ func generateUpstreamServers(opts Options, certStore CertificateStore, cfg consu
 		i := emptyServerSlots[0]
 		emptyServerSlots = emptyServerSlots[1:]
 
-		servers[i].Address = s.Host
+		servers[i].Name = s.Name
+		servers[i].Address = s.Address
 		servers[i].Port = int64p(s.Port)
 		servers[i].Weight = int64p(s.Weight)
 		servers[i].Maintenance = models.ServerMaintenanceDisabled


### PR DESCRIPTION
Mostly to make the HAproxy logs more useful for tracing the requests.

Although it doesn't make much sense without #51 it works independently so it can be reviewed in the same way.

Also related to #45.