### PR TITLE
Intentions: Add cache for Consul authorization and certificate parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,4 +24,5 @@ require (
 	github.com/stretchr/testify v1.4.0
 	gopkg.in/d4l3k/messagediff.v1 v1.2.1
 	gopkg.in/mcuadros/go-syslog.v2 v2.2.1
+	zvelo.io/ttlru v1.0.9
 )

--- a/go.sum
+++ b/go.sum
@@ -554,3 +554,5 @@ k8s.io/apimachinery v0.0.0-20190223001710-c182ff3b9841/go.mod h1:ccL7Eh7zubPUSh9
 k8s.io/client-go v8.0.0+incompatible h1:tTI4hRmb1DRMl4fG6Vclfdi6nTM82oIrTT7HfitmxC4=
 k8s.io/client-go v8.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 launchpad.net/gocheck v0.0.0-20140225173054-000000000087/go.mod h1:hj7XX3B/0A+80Vse0e+BUHsHMTEhd0O4cpUHr/e/BUM=
+zvelo.io/ttlru v1.0.9 h1:M/xLk0CjtxR27r0VEVNKkyLnLx446j3sacaVSHDYTDw=
+zvelo.io/ttlru v1.0.9/go.mod h1:wrcCylCKdCPx7HlN70P872PBl7JRFeiQfDzsx7t9Sps=

--- a/haproxy/spoe.go
+++ b/haproxy/spoe.go
@@ -3,8 +3,11 @@ package haproxy
 import (
 	"crypto/x509"
 	"fmt"
+	"sync"
+	"time"
 
 	log "github.com/sirupsen/logrus"
+	"zvelo.io/ttlru"
 
 	spoe "github.com/criteo/haproxy-spoe-go"
 	"github.com/haproxytech/haproxy-consul-connect/consul"
@@ -13,15 +16,32 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	authzTimeout = time.Second
+	cacheTTL     = time.Second
+)
+
+type cacheEntry struct {
+	Value bool
+	At    time.Time
+	C     chan struct{}
+}
+
 type SPOEHandler struct {
 	c   *api.Client
 	cfg func() consul.Config
+
+	certCache     ttlru.Cache
+	authCache     map[string]*cacheEntry
+	authCacheLock sync.Mutex
 }
 
 func NewSPOEHandler(c *api.Client, cfg func() consul.Config) *SPOEHandler {
 	return &SPOEHandler{
-		c:   c,
-		cfg: cfg,
+		c:         c,
+		cfg:       cfg,
+		certCache: ttlru.New(2048, ttlru.WithTTL(time.Minute)),
+		authCache: map[string]*cacheEntry{},
 	}
 }
 
@@ -37,32 +57,25 @@ func (h *SPOEHandler) Handler(args []spoe.Message) ([]spoe.Action, error) {
 			return nil, fmt.Errorf("spoe handler: expected cert bytes in message, got: %+v", m.Args)
 		}
 
-		cert, err := x509.ParseCertificate(certBytes)
+		cert, err := h.decodeCertificate(certBytes)
 		if err != nil {
-			return nil, errors.Wrap(err, "spoe handler")
+			log.Errorf("spoe handler: %s", err)
+			return nil, err
 		}
-
-		sourceApp := ""
 
 		certURI, err := connect.ParseCertURI(cert.URIs[0])
 		if err != nil {
-			log.Printf("connect: invalid leaf certificate URI")
+			log.Error("connect: invalid leaf certificate URI")
 			return nil, errors.New("connect: invalid leaf certificate URI")
 		}
 
-		// Perform AuthZ
-		resp, err := h.c.Agent().ConnectAuthorize(&api.AgentAuthorizeParams{
-			Target:           cfg.ServiceName,
-			ClientCertURI:    certURI.URI().String(),
-			ClientCertSerial: connect.HexString(cert.SerialNumber.Bytes()),
-		})
+		sourceApp := ""
+		authorized, err := h.isAuthorized(cfg.ServiceName, certURI.URI().String(), cert.SerialNumber.Bytes())
 		if err != nil {
-			return nil, errors.Wrap(err, "spoe handler: authz call failed")
+			log.Errorf("spoe handler: %s", err)
+			return nil, err
 		}
 
-		log.Debugf("spoe: auth response from %s authorized=%v", certURI.URI().String(), resp.Authorized)
-
-		authorized := resp.Authorized
 		if sis, ok := certURI.(*connect.SpiffeIDService); ok {
 			sourceApp = sis.Service
 		}
@@ -85,4 +98,74 @@ func (h *SPOEHandler) Handler(args []spoe.Message) ([]spoe.Action, error) {
 		}, nil
 	}
 	return nil, nil
+}
+
+func (h *SPOEHandler) isAuthorized(target, uri string, serial []byte) (bool, error) {
+	h.authCacheLock.Lock()
+	entry, ok := h.authCache[uri]
+	now := time.Now()
+	if !ok || now.Sub(entry.At) > cacheTTL {
+		entry = &cacheEntry{
+			At: now,
+			C:  make(chan struct{}),
+		}
+		h.authCache[uri] = entry
+		h.authCacheLock.Unlock()
+
+		go func() {
+			auth, err := h.fetchAutz(target, uri, serial)
+
+			h.authCacheLock.Lock()
+			defer h.authCacheLock.Unlock()
+
+			if err != nil {
+				log.Error(err)
+				entry.Value = false
+				// force refech on next request
+				entry.At = time.Time{}
+			} else {
+				entry.Value = auth
+			}
+
+			// notify waiting requets
+			close(entry.C)
+		}()
+	} else {
+		h.authCacheLock.Unlock()
+	}
+
+	select {
+	case <-time.After(authzTimeout):
+		return false, fmt.Errorf("authz call failed: timeout after %s", authzTimeout)
+	case <-entry.C:
+		return entry.Value, nil
+	}
+}
+
+func (h *SPOEHandler) fetchAutz(target, uri string, serial []byte) (bool, error) {
+	resp, err := h.c.Agent().ConnectAuthorize(&api.AgentAuthorizeParams{
+		Target:           target,
+		ClientCertURI:    uri,
+		ClientCertSerial: connect.HexString(serial),
+	})
+	if err != nil {
+		return false, errors.Wrap(err, "authz call failed")
+	}
+
+	return resp.Authorized, nil
+}
+
+func (h *SPOEHandler) decodeCertificate(b []byte) (*x509.Certificate, error) {
+	certCacheKey := string(b)
+	if v, ok := h.certCache.Get(certCacheKey); ok {
+		return v.(*x509.Certificate), nil
+	}
+
+	cert, err := x509.ParseCertificate(b)
+	if err != nil {
+		return nil, err
+	}
+	h.certCache.Set(certCacheKey, cert)
+
+	return cert, nil
 }


### PR DESCRIPTION
With intentions enabled, a lot of time is spent parsing the client
certificate and calling consul.
This adds a cache for both, taking care of in flight requests resulting
in much better performance.