### PR TITLE
Set http-reuse always by default

### DIFF
--- a/haproxy/config.go
+++ b/haproxy/config.go
@@ -29,6 +29,9 @@ global
 	nbproc 1
 	nbthread {{.NbThread}}
 
+defaults
+	http-reuse always
+
 userlist controller
 	user {{.DataplaneUser}} insecure-password {{.DataplanePass}}
 `


### PR DESCRIPTION
Reuse tcp connections to reduce tcp / tls handlshakes.