### PR TITLE
Fix: new certificates not upgraded on existing servers

### DIFF
--- a/haproxy/state/from_ha_test.go
+++ b/haproxy/state/from_ha_test.go
@@ -149,6 +149,6 @@ func TestFromHA(t *testing.T) {
 	cfgDir, err := ioutil.TempDir("", fmt.Sprintf("%s_*", t.Name()))
 	require.NoError(t, err)
 
-	state := GetTestHAConfig(cfgDir)
+	state := GetTestHAConfig(cfgDir, "")
 	testCfg(t, cfgDir, state)
 }

--- a/haproxy/state/upstream.go
+++ b/haproxy/state/upstream.go
@@ -130,8 +130,11 @@ func generateUpstreamServers(opts Options, certStore CertificateStore, cfg consu
 
 	// Add new servers
 	for _, s := range cfg.Nodes {
-		_, ok := serversIdx[idxConsulNode(s)]
+		i, ok := serversIdx[idxConsulNode(s)]
 		if ok {
+			// if the server exists, just update its certificate in case they changed
+			servers[i].SslCafile = caPath
+			servers[i].SslCertificate = crtPath
 			continue
 		}
 
@@ -149,7 +152,7 @@ func generateUpstreamServers(opts Options, certStore CertificateStore, cfg consu
 			}
 		}
 
-		i := emptyServerSlots[0]
+		i = emptyServerSlots[0]
 		emptyServerSlots = emptyServerSlots[1:]
 
 		servers[i].Address = s.Host


### PR DESCRIPTION
Fix a bug that kept old certificates in server backends on existing
servers.