### PR TITLE
Improve stats

### DIFF
--- a/haproxy/config.go
+++ b/haproxy/config.go
@@ -14,13 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const (
-	dataplaneUser = "haproxy"
-)
-
-var dataplanePass string
-
-var baseCfgTmpl = `
+const baseCfgTmpl = `
 global
 	master-worker
     stats socket {{.SocketPath}} mode 600 level admin expose-fd listeners
@@ -71,6 +65,8 @@ type haConfig struct {
 	StatsSock               string
 	DataplaneSock           string
 	DataplaneTransactionDir string
+	DataplaneUser           string
+	DataplanePass           string
 	LogsSock                string
 }
 
@@ -116,14 +112,15 @@ func newHaConfig(baseDir string, sd *lib.Shutdown) (*haConfig, error) {
 		}
 	}()
 
-	dataplanePass = createRandomString()
+	cfg.DataplanePass = createRandomString()
+	cfg.DataplaneUser = "hapeoxy"
 
 	err = tmpl.Execute(cfgFile, baseParams{
 		NbThread:      runtime.GOMAXPROCS(0),
 		SocketPath:    cfg.StatsSock,
 		LogsPath:      cfg.LogsSock,
-		DataplaneUser: dataplaneUser,
-		DataplanePass: dataplanePass,
+		DataplaneUser: cfg.DataplaneUser,
+		DataplanePass: cfg.DataplanePass,
 	})
 	if err != nil {
 		sd.Done()

--- a/haproxy/state.go
+++ b/haproxy/state.go
@@ -25,6 +25,7 @@ func (h *HAProxy) watch(sd *lib.Shutdown) error {
 	var currentConfig consul.Config
 	dirty := false
 	started := false
+	ready := false
 
 	waitAndRetry := func() {
 		time.Sleep(retryBackoff)
@@ -69,7 +70,6 @@ func (h *HAProxy) watch(sd *lib.Shutdown) error {
 				return err
 			}
 			started = true
-			close(h.Ready)
 		}
 
 		if dirty {
@@ -120,6 +120,11 @@ func (h *HAProxy) watch(sd *lib.Shutdown) error {
 			log.Error(err)
 			waitAndRetry()
 			continue
+		}
+
+		if !ready {
+			close(h.Ready)
+			ready = true
 		}
 
 		currentState = newState

--- a/haproxy/stats/stats.go
+++ b/haproxy/stats/stats.go
@@ -1,0 +1,108 @@
+package stats
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/haproxytech/haproxy-consul-connect/haproxy/dataplane"
+	"github.com/hashicorp/consul/api"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	log "github.com/sirupsen/logrus"
+)
+
+type Config struct {
+	RegisterService bool
+	ListenAddr      string
+	ServiceName     string
+	ServiceID       string
+}
+
+type Stats struct {
+	cfg          Config
+	consulClient *api.Client
+	dpapi        *dataplane.Dataplane
+	ready        chan struct{}
+}
+
+func New(consulClient *api.Client, dpapi *dataplane.Dataplane, ready chan struct{}, cfg Config) *Stats {
+	return &Stats{
+		cfg:          cfg,
+		consulClient: consulClient,
+		dpapi:        dpapi,
+		ready:        ready,
+	}
+}
+
+func (s *Stats) Run() error {
+	if s.cfg.RegisterService {
+		go s.register()
+	}
+
+	go s.runMetrics()
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	mux.Handle("/ready", http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		<-s.ready
+		rw.Write([]byte("ready"))
+	}))
+	mux.Handle("/health", http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		ok := false
+		select {
+		case <-s.ready:
+			ok = true
+		default:
+		}
+
+		if ok {
+			rw.Write([]byte("ok"))
+		} else {
+			rw.WriteHeader(500)
+			rw.Write([]byte("starting..."))
+		}
+	}))
+
+	log.Infof("Starting stats server at %s", s.cfg.ListenAddr)
+	err := http.ListenAndServe(s.cfg.ListenAddr, mux)
+	if err != nil {
+		log.Errorf("error starting stats server: %s", err)
+	}
+
+	return nil
+}
+
+func (s *Stats) register() {
+	_, portStr, err := net.SplitHostPort(s.cfg.ListenAddr)
+	if err != nil {
+		log.Errorf("cannot parse stats listen addr: %s", err)
+	}
+	port, _ := strconv.Atoi(portStr)
+
+	reg := func() {
+		err = s.consulClient.Agent().ServiceRegister(&api.AgentServiceRegistration{
+			ID:   fmt.Sprintf("%s-connect-stats", s.cfg.ServiceID),
+			Name: fmt.Sprintf("%s-connect-stats", s.cfg.ServiceName),
+			Port: port,
+			Checks: api.AgentServiceChecks{
+				&api.AgentServiceCheck{
+					HTTP:                           fmt.Sprintf("http://localhost:%d/metrics", port),
+					Interval:                       (10 * time.Second).String(),
+					DeregisterCriticalServiceAfter: time.Minute.String(),
+				},
+			},
+			Tags: []string{"connect-stats"},
+		})
+		if err != nil {
+			log.Errorf("cannot register stats service: %s", err)
+		}
+	}
+
+	reg()
+
+	for range time.Tick(time.Minute) {
+		reg()
+	}
+}


### PR DESCRIPTION
* Remove per server starts, which generate a lot of metrics and refer to
unhelpful srv_N instead of the real server name
* Ignore SPOE backend stats
* Fix response time metrics which was using the session time instead of
response time
* Add total requests metrics to produce nicer graph with prometheus'
rate() func
