### PR TITLE
Raise ulimit-n to 65536

### DIFF
--- a/haproxy/config.go
+++ b/haproxy/config.go
@@ -22,6 +22,7 @@ global
 	tune.ssl.default-dh-param 1024
 	nbproc 1
 	nbthread {{.NbThread}}
+	ulimit-n 65536
 
 defaults
 	http-reuse always


### PR DESCRIPTION
The default 4040 value is not enough for high load situations