### PR TITLE
Allow to pass haproxy defaults and global parameters as flag

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/haproxytech/haproxy-consul-connect/haproxy"
+)
+
+type stringSliceFlag []string
+
+func (i *stringSliceFlag) String() string {
+	return ""
+}
+
+func (i *stringSliceFlag) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}
+
+func makeHAProxyParams(flags stringSliceFlag) (haproxy.HAProxyParams, error) {
+	params := haproxy.HAProxyParams{
+		Defaults: map[string]string{},
+		Globals:  map[string]string{},
+	}
+
+	for _, flag := range flags {
+		parts := strings.Split(flag, "=")
+		if len(parts) != 2 {
+			return params, fmt.Errorf("bad haproxy-param flag %s, expected {type}.{name}={value}", flag)
+		}
+
+		dot := strings.IndexByte(parts[0], '.')
+		if dot == -1 {
+			return params, fmt.Errorf("bad haproxy-param flag %s, expected {type}.{name}={value}", flag)
+		}
+
+		var t map[string]string
+		switch parts[0][:dot] {
+		case "defaults":
+			t = params.Defaults
+		case "global":
+			t = params.Globals
+		default:
+			return params, fmt.Errorf("bad haproxy-param flag %s, param type must be `defaults` or `global`", flag)
+		}
+
+		t[parts[0][dot+1:]] = parts[1]
+	}
+
+	return params, nil
+}

--- a/flags_test.go
+++ b/flags_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/haproxytech/haproxy-consul-connect/haproxy"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeHAProxyParams(t *testing.T) {
+	flags := stringSliceFlag{
+		"defaults.test.with.dots=3",
+		"defaults.another=abdc",
+		"global.with.spaces=hey I have spaces",
+		"global.with.dots=hey.I.have.dots",
+	}
+
+	r, err := makeHAProxyParams(flags)
+	require.NoError(t, err)
+
+	require.Equal(t, haproxy.HAProxyParams{
+		Defaults: map[string]string{
+			"test.with.dots": "3",
+			"another":        "abdc",
+		},
+		Globals: map[string]string{
+			"with.spaces": "hey I have spaces",
+			"with.dots":   "hey.I.have.dots",
+		},
+	}, r)
+}

--- a/haproxy/haproxy.go
+++ b/haproxy/haproxy.go
@@ -47,7 +47,7 @@ func New(consulClient *api.Client, cfg chan consul.Config, opts Options) *HAProx
 }
 
 func (h *HAProxy) Run(sd *lib.Shutdown) error {
-	hc, err := newHaConfig(h.opts.ConfigBaseDir, sd)
+	hc, err := newHaConfig(h.opts.ConfigBaseDir, h.opts.HAProxyParams, sd)
 	if err != nil {
 		return err
 	}

--- a/haproxy/options.go
+++ b/haproxy/options.go
@@ -1,5 +1,30 @@
 package haproxy
 
+type HAProxyParams struct {
+	Defaults map[string]string
+	Globals  map[string]string
+}
+
+func (p HAProxyParams) With(other HAProxyParams) HAProxyParams {
+	new := HAProxyParams{
+		Defaults: map[string]string{},
+		Globals:  map[string]string{},
+	}
+	for k, v := range p.Defaults {
+		new.Defaults[k] = v
+	}
+	for k, v := range other.Defaults {
+		new.Defaults[k] = v
+	}
+	for k, v := range p.Globals {
+		new.Globals[k] = v
+	}
+	for k, v := range other.Globals {
+		new.Globals[k] = v
+	}
+	return new
+}
+
 type Options struct {
 	HAProxyBin           string
 	DataplaneBin         string
@@ -9,4 +34,5 @@ type Options struct {
 	StatsListenAddr      string
 	StatsRegisterService bool
 	LogRequests          bool
+	HAProxyParams        HAProxyParams
 }


### PR DESCRIPTION
To give better control to users in fine tuning haproxy when using
connect, give the ability to pass command line flags to modify haproxy's
configuration.
The flags are in the form {type}.{name}={value} and can be repeated.
Examples:
* -haproxy-param "global.tune.bufsize=33792"
* -haproxy-param "default.retries=1"