### PR TITLE
MINOR: stats: Add a config option to set Consul service address

### DIFF
--- a/haproxy/haproxy.go
+++ b/haproxy/haproxy.go
@@ -152,6 +152,7 @@ func (h *HAProxy) startStats() error {
 			ListenAddr:      h.opts.StatsListenAddr,
 			ServiceName:     h.currentConsulConfig.ServiceName,
 			ServiceID:       h.currentConsulConfig.ServiceID,
+			ServiceAddr:     h.opts.StatsServiceAddr,
 		})
 
 	go func() {

--- a/haproxy/options.go
+++ b/haproxy/options.go
@@ -8,5 +8,6 @@ type Options struct {
 	EnableIntentions     bool
 	StatsListenAddr      string
 	StatsRegisterService bool
+	StatsServiceAddr     string
 	LogRequests          bool
 }

--- a/haproxy/stats/stats.go
+++ b/haproxy/stats/stats.go
@@ -18,6 +18,7 @@ type Config struct {
 	ListenAddr      string
 	ServiceName     string
 	ServiceID       string
+	ServiceAddr     string
 }
 
 type Stats struct {
@@ -81,14 +82,20 @@ func (s *Stats) register() {
 	}
 	port, _ := strconv.Atoi(portStr)
 
+	serviceCheckAddr := "localhost"
+	if s.cfg.ServiceAddr != "" {
+		serviceCheckAddr = s.cfg.ServiceAddr
+	}
+
 	reg := func() {
 		err = s.consulClient.Agent().ServiceRegister(&api.AgentServiceRegistration{
-			ID:   fmt.Sprintf("%s-connect-stats", s.cfg.ServiceID),
-			Name: fmt.Sprintf("%s-connect-stats", s.cfg.ServiceName),
-			Port: port,
+			ID:      fmt.Sprintf("%s-connect-stats", s.cfg.ServiceID),
+			Name:    fmt.Sprintf("%s-connect-stats", s.cfg.ServiceName),
+			Address: s.cfg.ServiceAddr,
+			Port:    port,
 			Checks: api.AgentServiceChecks{
 				&api.AgentServiceCheck{
-					HTTP:                           fmt.Sprintf("http://localhost:%d/metrics", port),
+					HTTP:                           fmt.Sprintf("http://%s:%d/metrics", serviceCheckAddr, port),
 					Interval:                       (10 * time.Second).String(),
 					DeregisterCriticalServiceAfter: time.Minute.String(),
 				},

--- a/main.go
+++ b/main.go
@@ -70,6 +70,7 @@ func main() {
 	haproxyCfgBasePath := flag.String("haproxy-cfg-base-path", "/tmp", "Haproxy binary path")
 	statsListenAddr := flag.String("stats-addr", "", "Listen addr for stats server")
 	statsServiceRegister := flag.Bool("stats-service-register", false, "Register a consul service for connect stats")
+	statsServiceAddr := flag.String("stats-service-addr", "", "Specify the consul service address for connect stats")
 	enableIntentions := flag.Bool("enable-intentions", false, "Enable Connect intentions")
 	token := flag.String("token", "", "Consul ACL token")
 	flag.Parse()
@@ -144,6 +145,7 @@ func main() {
 		EnableIntentions:     *enableIntentions,
 		StatsListenAddr:      *statsListenAddr,
 		StatsRegisterService: *statsServiceRegister,
+		StatsServiceAddr:     *statsServiceAddr,
 		LogRequests:          ll == log.TraceLevel,
 	})
 	sd.Add(1)


### PR DESCRIPTION
In some cases, especially in a containers environment with a single Consul agent running on the host, it is mandatory to specify the service address otherwise it will point to an incorrect IP, and the check will be performed on the host instead of the container.